### PR TITLE
Quickfixing something that looks like an issue

### DIFF
--- a/django_elasticsearch_dsl/management/commands/search_index.py
+++ b/django_elasticsearch_dsl/management/commands/search_index.py
@@ -58,7 +58,7 @@ class Command(BaseCommand):
             '--chunk-size',
             metavar='chunk_size',
             type=int,
-            nargs='*',
+            #nargs='*',
             help="Chunk size for bulk insert/update."
         )
 


### PR DESCRIPTION
with nargs='*' resulting argument is an array where as we'd like it to be a single integer value.